### PR TITLE
Make analytics configurable via env vars

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,19 @@ cd DealDeli-final
 docker-compose up --build
 ```
 
+### Environment Variables
+
+The microservices expect the following variables when running via
+`docker-compose`. Default values are shown in parentheses:
+
+- `MYSQL_HOST` (`mysql_container`)
+- `MYSQL_USER` (`root`)
+- `MYSQL_PASSWORD` (`password`)
+- `MYSQL_DATABASE` (`DealDeli_data`)
+
+These are passed automatically in `docker-compose.yml` but can be
+overridden if needed.
+
 Once running, the services will be available at:
 
 | Service                | URL                                |

--- a/analytics_microservice/db.py
+++ b/analytics_microservice/db.py
@@ -1,9 +1,17 @@
 import mysql.connector
+import os
 
 def get_connection():
+    """Create and return a MySQL connection using environment variables."""
+
+    host = os.environ.get("MYSQL_HOST", "mysql_container")
+    user = os.environ.get("MYSQL_USER", "root")
+    password = os.environ.get("MYSQL_PASSWORD", "password")
+    database = os.environ.get("MYSQL_DATABASE", "DealDeli_data")
+
     return mysql.connector.connect(
-        host="host.docker.internal",
-        user="root",
-        password="Welcom_praj@123",
-        database="dealdeli_data"
+        host=host,
+        user=user,
+        password=password,
+        database=database
     )

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,7 +5,7 @@ services:
     image: mysql:8.0
     container_name: mysql_container
     environment:
-      MYSQL_ROOT_PASSWORD: UoS@2025
+      MYSQL_ROOT_PASSWORD: password
       MYSQL_DATABASE: DealDeli_data
     ports:
       - "3306:3306"
@@ -22,8 +22,8 @@ services:
     environment:
       MYSQL_HOST: mysql
       MYSQL_USER: root
-      MYSQL_PASSWORD: ${MYSQL_ROOT_PASSWORD}
-      MYSQL_DATABASE: ${MYSQL_DATABASE}
+      MYSQL_PASSWORD: password
+      MYSQL_DATABASE: DealDeli_data
     depends_on:
       - mysql_container
     networks:
@@ -35,7 +35,7 @@ services:
       - "5002:5002"
     environment:
       MYSQL_USER: root
-      MYSQL_PASSWORD: UoS@2025
+      MYSQL_PASSWORD: password
       MYSQL_HOST: mysql_container
       MYSQL_DATABASE: DealDeli_data
     networks:
@@ -47,10 +47,10 @@ services:
     ports:
       - "5003:5003"
     environment:
-      MYSQL_HOST: mysql
+      MYSQL_HOST: mysql_container
       MYSQL_USER: root
-      MYSQL_PASSWORD: ${MYSQL_ROOT_PASSWORD}
-      MYSQL_DATABASE: ${MYSQL_DATABASE}
+      MYSQL_PASSWORD: password
+      MYSQL_DATABASE: DealDeli_data
     depends_on:
       - mysql_container
     networks:

--- a/price_microservice/app.py
+++ b/price_microservice/app.py
@@ -16,7 +16,7 @@ CORS(app, origins=["http://localhost:5501"])
 
 # Load from env or fallback
 user = os.getenv("MYSQL_USER", "root")
-password = quote_plus(os.getenv("MYSQL_PASSWORD", "UoS@2025"))  # Escape special chars
+password = quote_plus(os.getenv("MYSQL_PASSWORD", "password"))  # Escape special chars
 host = os.getenv("MYSQL_HOST", "mysql_container")
 db_name = os.getenv("MYSQL_DATABASE", "dealdeli_data")
 


### PR DESCRIPTION
## Summary
- sanitize credentials in analytics DB connector
- update docker-compose with placeholder passwords
- clean up README environment variable examples
- remove personal credential from price service config

## Testing
- `python -m py_compile analytics_microservice/db.py`
- `docker-compose config` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6848840922ac8332860e631f333d77b3