### PR TITLE
Fix microservice connectivity

### DIFF
--- a/analytics_microservice/Dockerfile
+++ b/analytics_microservice/Dockerfile
@@ -28,6 +28,6 @@ EXPOSE 5003
 #     MYSQL_DATABASE=dealdeli_data
 
 # Run the application
-CMD ["flask", "run", "--port=5003"]
+CMD ["flask", "run", "--host=0.0.0.0", "--port=5003"]
 
 

--- a/analytics_microservice/db.py
+++ b/analytics_microservice/db.py
@@ -1,9 +1,10 @@
 import mysql.connector
+import os
 
 def get_connection():
     return mysql.connector.connect(
-        host="host.docker.internal",
-        user="root",
-        password="Welcom_praj@123",
-        database="dealdeli_data"
+        host=os.getenv("MYSQL_HOST", "mysql_container"),
+        user=os.getenv("MYSQL_USER", "root"),
+        password=os.getenv("MYSQL_PASSWORD", os.getenv("MYSQL_ROOT_PASSWORD", "UoS@2025")),
+        database=os.getenv("MYSQL_DATABASE", "dealdeli_data")
     )

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,7 +21,7 @@ services:
       - "5001:5001"
     environment:
       <<: *mysql_env
-      MYSQL_HOST: mysql
+      MYSQL_HOST: mysql_container
       MYSQL_USER: root
     depends_on:
       - mysql_container
@@ -47,8 +47,9 @@ services:
       - "5003:5003"
     environment:
       <<: *mysql_env
-      MYSQL_HOST: mysql
+      MYSQL_HOST: mysql_container
       MYSQL_USER: root
+      MYSQL_PASSWORD: UoS@2025
     depends_on:
       - mysql_container
     networks:


### PR DESCRIPTION
## Summary
- configure Flask analytics service to listen on all interfaces
- make analytics DB connector configurable via env vars
- align docker-compose service names and credentials

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68488e28fb10833289755ef49f3792dd